### PR TITLE
Fix issue with permitted packets causing massive API traffic spikes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-role-call",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-role-call",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Class able to facilitate the management of role call in Discord",
   "main": "src/RoleCall.js",
   "peerDependencies": {

--- a/src/RoleCall.js
+++ b/src/RoleCall.js
@@ -97,7 +97,7 @@ class RoleCall extends EventEmitter
 	rawPacket(packet)
 	{
 		// We don't want this to run on unrelated packets
-		if (!packet.d.emoji) return;
+		if (!['MESSAGE_REACTION_ADD','MESSAGE_REACTION_REMOVE'].includes(packet.t)) return;
 		// We don't want to run on any message other than the RoleCall target
 		if(packet.d.message_id != this.message.id) return;
 		// Grab the channel the message is from


### PR DESCRIPTION
Packets that should have had no processing done were having some processing done, including fetch requests against the API

Closes #7 